### PR TITLE
Show updated packages and changed files directly

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,8 +15,7 @@
         </testsuite>
     </testsuites>
     <logging>
-        <log type="coverage-html" target="data/tmp/coverage" title="kco_php"
-             charset="UTF-8" yui="true" highlight="true"
+        <log type="coverage-html" target="data/tmp/coverage"
              lowUpperBound="35" highLowerBound="70" />
         <log type="coverage-clover" target="data/tmp/coverage.xml" />
     </logging>

--- a/templates/pull-request-body.twig
+++ b/templates/pull-request-body.twig
@@ -14,9 +14,13 @@ Some times an update also needs new or updated dependencies to be installed. Eve
 
 Here is a list of changed files between the version you use, and the version this pull request updates to:
 
+<details>
+  <summary>List of changed files</summary>
+
   {% for file in changed_files %}
     {{ file }}
   {% endfor %}
+</details>
 {% endif %}
 
 {% if changelog %}

--- a/templates/pull-request-body.twig
+++ b/templates/pull-request-body.twig
@@ -3,14 +3,10 @@ If you have a high test coverage index, and your tests for this pull request are
 {% if updated_list %}
 ### Updated packages
 
-Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here.
-
-<details>
-<summary>List of updated packages</summary>
+Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here:
 
 {{ updated_list }}
 
-</details>
 {% endif %}
 {% if changed_files %}
 
@@ -18,13 +14,9 @@ Some times an update also needs new or updated dependencies to be installed. Eve
 
 Here is a list of changed files between the version you use, and the version this pull request updates to:
 
-<details>
-  <summary>List of changed files</summary>
-
   {% for file in changed_files %}
     {{ file }}
   {% endfor %}
-</details>
 {% endif %}
 
 {% if changelog %}

--- a/tests/Unit/UnitTest.php
+++ b/tests/Unit/UnitTest.php
@@ -86,19 +86,16 @@ class UnitTest extends TestCase
         $update = new ViolinistUpdate();
         $update->setUpdatedList($update_items);
         $body = $message->getPullRequestBody($update);
+        $a = 'b';
         $this->assertEquals('If you have a high test coverage index, and your tests for this pull request are passing, it should be both safe and recommended to merge this update.
 
 ### Updated packages
 
-Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here.
-
-<details>
-<summary>List of updated packages</summary>
+Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here:
 
 - first/updated: 2.0.1 (updated from 2.0.2)
 - other/new: 2.0.0 (new package, previously not installed)
 
-</details>
 
 
 ***
@@ -124,16 +121,12 @@ This is an automated pull request from [Violinist](https://violinist.io/): Conti
 
 ### Updated packages
 
-Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here.
-
-<details>
-<summary>List of updated packages</summary>
+Some times an update also needs new or updated dependencies to be installed. Even if this branch is for updating one dependency, it might contain other installs or updates. All of the updates in this branch can be found here:
 
 - first/updated: 2.0.1 (updated from 2.0.2)
 - other/new: 2.0.0 (new package, previously not installed)
 - third/removed x (package was removed)
 
-</details>
 
 
 ***


### PR DESCRIPTION
Edit: This is a proposed change for the pull request body. Forgot to mention that.

Currently updated packages and changed files are hidden behind collapsed details sections, but I feel this is important information that you should read through for every Violinist PR to ensure you know what changes you're actually merging. 

I assume these sections are collapsed because they can become long, but if they are long that's even more reason to read through them. Now if they are long, ie. the PR updates a lot of packages and/or changes a lot of files, you're immediately aware of that fact.